### PR TITLE
Fix install command

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ fcm provides a Git commit message template fuzzy search feature.
 ### Install
 
 ```
-$ go get github.com/wataboru/git-fuzzy-find-commit-message
+$ go get github.com/wataboru/git-fuzzy-find-commit-message/cmd/fcm
 ```
 
 Download from [releases](https://github.com/wataboru/git-fuzzy-find-commit-message/releases)


### PR DESCRIPTION
# Description

The install command has an error because a go file does not exist.

```
$ go get github.com/wataboru/git-fuzzy-find-commit-message
can't load package: package github.com/wataboru/git-fuzzy-find-commit-message: no Go files in /local/path/go/src/github.com/wataboru/git-fuzzy-find-commit-message
```

So, add path `/cmd/fcm` to `go get`.